### PR TITLE
feat: restore projects section on homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .astro/
 .cursor/
 .claude/
+.playwright-mcp/
 
 node_modules/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ dist/
 
 CLAUDE.md
 AGENTS.md
+
+docs/superpowers/

--- a/content/projects/ai-digest.yml
+++ b/content/projects/ai-digest.yml
@@ -1,0 +1,3 @@
+name: AI Digest
+slug: ai-digest
+order: 1

--- a/content/projects/obsidian-budget-planner-plugin.yml
+++ b/content/projects/obsidian-budget-planner-plugin.yml
@@ -1,3 +1,3 @@
 name: Obsidian Budget Planner Plugin
 slug: obsidian-budget-planner-plugin
-order: 1
+order: 2

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,7 +26,7 @@ const socialLinks = [
 ];
 ---
 
-<footer class="border-t border-line bg-background-subtle">
+<footer class="border-t border-line bg-background">
   <div class="container py-12 md:py-16">
     <!-- Main Footer Content -->
     <div class="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-6">

--- a/src/components/home/BlogSection.astro
+++ b/src/components/home/BlogSection.astro
@@ -11,7 +11,7 @@ type Props = {
 const { latestPosts } = Astro.props;
 ---
 
-<section id="blog" class="py-12 md:py-16 bg-background-subtle">
+<section id="blog" class="py-12 md:py-16">
   <div class="container">
     <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
       <div>

--- a/src/components/home/BlogSection.astro
+++ b/src/components/home/BlogSection.astro
@@ -15,7 +15,7 @@ const { latestPosts } = Astro.props;
   <div class="container">
     <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-8">
       <div>
-        <span class="section-label mb-3">04 — Writing</span>
+        <span class="section-label mb-3">05 — Writing</span>
         <div class="flex items-center gap-3">
           <h2 class="text-foreground">Latest articles</h2>
           <a

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -10,7 +10,7 @@ type Props = {
 const { mailProfileLink, linkedinProfileLink } = Astro.props;
 ---
 
-<section id="contact" class="py-12 md:py-16">
+<section id="contact" class="py-12 md:py-16 bg-background-subtle">
   <div class="container">
     <div class="max-w-2xl mx-auto text-center">
       <span class="section-label justify-center mb-3">06 — Contact</span>

--- a/src/components/home/ContactSection.astro
+++ b/src/components/home/ContactSection.astro
@@ -13,7 +13,7 @@ const { mailProfileLink, linkedinProfileLink } = Astro.props;
 <section id="contact" class="py-12 md:py-16">
   <div class="container">
     <div class="max-w-2xl mx-auto text-center">
-      <span class="section-label justify-center mb-3">05 — Contact</span>
+      <span class="section-label justify-center mb-3">06 — Contact</span>
       <h2 class="text-foreground mb-4">Let's work together</h2>
       <p class="text-foreground-secondary mb-6 max-w-lg mx-auto">
         Interested in collaboration? Get in touch.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,7 @@ import Layout from '../components/Layout.astro';
 import HeroSection from '../components/home/HeroSection.astro';
 import AboutSection from '../components/home/AboutSection.astro';
 import WorkHistorySection from '../components/home/WorkHistorySection.astro';
+import ProjectsSection from '../components/home/ProjectsSection.astro';
 import BlogSection from '../components/home/BlogSection.astro';
 import ContactSection from '../components/home/ContactSection.astro';
 
@@ -87,8 +88,7 @@ const expertise = [
   <HeroSection />
   <AboutSection expertise={expertise} />
   <WorkHistorySection />
-  {/* TODO: Re-enable Projects section when new projects are ready */}
-  {/* <ProjectsSection projects={projects} githubProfileLink={GITHUB_PROFILE_LINK} /> */}
+  <ProjectsSection projects={projects} githubProfileLink={GITHUB_PROFILE_LINK} />
   {allPosts.length > 0 && <BlogSection latestPosts={latestPosts} />}
   <ContactSection mailProfileLink={MAIL_PROFILE_LINK} linkedinProfileLink={LINKEDIN_PROFILE_LINK} />
 </Layout>


### PR DESCRIPTION
## Summary

- Re-enable the Projects section on the homepage with two projects: AI Digest and Obsidian Budget Planner Plugin
- Add ai-digest as a new featured project (order 1), reorder Obsidian plugin to order 2
- Fix section numbering (04 Projects, 05 Writing, 06 Contact)
- Restore alternating section background pattern and align Footer with Header (`bg-background`)

## Test plan

- [x] Verify Projects section appears between Experience and Writing on homepage
- [x] Verify AI Digest card shows first with correct description, tags, and star count
- [x] Verify Obsidian Budget Planner Plugin card shows second
- [x] Verify section backgrounds alternate correctly (subtle/default)
- [x] Verify Footer background matches Header
- [x] Verify all three themes render correctly