### PR TITLE
Refresh project card copy

### DIFF
--- a/content/projects/ai-digest.yml
+++ b/content/projects/ai-digest.yml
@@ -2,3 +2,5 @@ name: AI Digest
 slug: ai-digest
 order: 1
 featured: false
+tagline: 'Personalized tech news digest powered by Claude Code and MCP.'
+tech: ['Claude Code', 'MCP', 'Markdown']

--- a/content/projects/obsidian-budget-planner-plugin.yml
+++ b/content/projects/obsidian-budget-planner-plugin.yml
@@ -2,3 +2,5 @@ name: Obsidian Budget Planner Plugin
 slug: obsidian-budget-planner-plugin
 order: 2
 featured: false
+tagline: 'Budget planning inside Obsidian notes, powered by markdown code blocks.'
+tech: ['Obsidian', 'TypeScript', 'Markdown']

--- a/content/projects/telegram-agent-kit.yml
+++ b/content/projects/telegram-agent-kit.yml
@@ -2,5 +2,5 @@ name: Telegram Agent Kit
 slug: telegram-agent-kit
 order: 4
 featured: true
-tagline: 'Build Telegram bots driven by AI agents, in TypeScript.'
-tech: ['TypeScript', 'AI agents', 'Telegram']
+tagline: 'Wire LLM agents to Telegram bots with a runtime-agnostic TypeScript library.'
+tech: ['TypeScript', 'LLM agents', 'Telegram']

--- a/content/projects/vaultmd.yml
+++ b/content/projects/vaultmd.yml
@@ -2,5 +2,5 @@ name: VaultMD
 slug: vaultmd
 order: 3
 featured: true
-tagline: 'Turn an Obsidian vault into a fast, self-hosted docs site.'
-tech: ['TypeScript', 'Astro', 'Markdown']
+tagline: 'Query an Obsidian-style markdown vault through a fast SQLite-backed data layer.'
+tech: ['TypeScript', 'Bun', 'SQLite']


### PR DESCRIPTION
Align the homepage project copy with the current GitHub repository positioning and make the non-featured project summaries more consistent.