### PR TITLE
Polish project card copy and ordering

### DIFF
--- a/content/projects/ai-digest.yml
+++ b/content/projects/ai-digest.yml
@@ -1,6 +1,6 @@
 name: AI Digest
 slug: ai-digest
-order: 1
+order: 3
 featured: false
-tagline: 'Personalized tech news digest powered by Claude Code and MCP.'
+tagline: 'Personalized Markdown tech digest that collects, deduplicates, and summarizes RSS feeds and GitHub releases.'
 tech: ['Claude Code', 'MCP', 'Markdown']

--- a/content/projects/obsidian-budget-planner-plugin.yml
+++ b/content/projects/obsidian-budget-planner-plugin.yml
@@ -1,6 +1,6 @@
 name: Obsidian Budget Planner Plugin
 slug: obsidian-budget-planner-plugin
-order: 2
+order: 4
 featured: false
-tagline: 'Budget planning inside Obsidian notes, powered by markdown code blocks.'
+tagline: 'Minimalist budget planning for Obsidian, managed directly inside markdown code blocks.'
 tech: ['Obsidian', 'TypeScript', 'Markdown']

--- a/content/projects/telegram-agent-kit.yml
+++ b/content/projects/telegram-agent-kit.yml
@@ -1,6 +1,6 @@
 name: Telegram Agent Kit
 slug: telegram-agent-kit
-order: 4
+order: 2
 featured: true
-tagline: 'Wire LLM agents to Telegram bots with a runtime-agnostic TypeScript library.'
+tagline: 'Runtime-agnostic TypeScript toolkit for wiring LLM agents to Telegram bots.'
 tech: ['TypeScript', 'LLM agents', 'Telegram']

--- a/content/projects/vaultmd.yml
+++ b/content/projects/vaultmd.yml
@@ -1,6 +1,6 @@
 name: VaultMD
 slug: vaultmd
-order: 3
+order: 1
 featured: true
-tagline: 'Query an Obsidian-style markdown vault through a fast SQLite-backed data layer.'
+tagline: 'Headless markdown-vault data layer with CRUD, backlinks, keyword search, and a SQLite index.'
 tech: ['TypeScript', 'Bun', 'SQLite']


### PR DESCRIPTION
Small content-only refresh for the homepage project cards: make the two current featured projects clearly read as the main focus, align ordering, and make the non-featured project taglines a bit more specific.