### PR TITLE
Address review findings from the GitHub-fetch removal

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Current order: Hero(default) → Selected work/Projects(default) → Writing(sub
 - Fonts configured via top-level `fonts` config (stabilized in Astro 6)
 - Tailwind 4 via Vite plugin (`@tailwindcss/vite`). There is no `tailwind.config.js` and no PostCSS config on purpose: Tailwind 4 ignores a legacy config file unless `global.css` opts in with `@config`, and its bundled Lightning CSS already handles vendor prefixing and minification. Configure the theme in the `@theme` block in `global.css`
 - Typography plugin for prose styling (`@tailwindcss/typography`)
-- Theme switching lives entirely in `Header.astro` (dropdown, `Cmd/Ctrl + /` cycling, OS-preference sync) plus the inline anti-flash script in `Layout.astro`. `src/config/themes.ts` is the single source of theme ids; the inline script duplicates the two ids because `is:inline` scripts cannot import
+- Theme switching lives entirely in `Header.astro` (dropdown, `Cmd/Ctrl + /` cycling, OS-preference sync) plus the inline anti-flash script in `Layout.astro`. `src/config/themes.ts` is the single source of theme ids (`LIGHT_THEME` / `DARK_THEME`); since `is:inline` scripts cannot import, `Layout.astro` passes them to the anti-flash script through a `data-theme-ids` attribute rather than hardcoding them
 - The scroll progress bar is pure CSS (`animation-timeline: scroll()` in `global.css`), decorative and `aria-hidden`. Browsers without scroll-driven animations simply do not show it
 - ESLint with TypeScript, Astro, and jsx-a11y plugins
 - External links in markdown open in new tabs (`rehype-external-links` in `astro.config.js`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ Current order: Hero(default) → Selected work/Projects(default) → Writing(sub
 - Fonts configured via top-level `fonts` config (stabilized in Astro 6)
 - Tailwind 4 via Vite plugin (`@tailwindcss/vite`). There is no `tailwind.config.js` and no PostCSS config on purpose: Tailwind 4 ignores a legacy config file unless `global.css` opts in with `@config`, and its bundled Lightning CSS already handles vendor prefixing and minification. Configure the theme in the `@theme` block in `global.css`
 - Typography plugin for prose styling (`@tailwindcss/typography`)
-- Theme switching lives entirely in `Header.astro` (dropdown, `Cmd/Ctrl + /` cycling, OS-preference sync) plus the inline anti-flash script in `Layout.astro`. `src/config/themes.ts` is the single source of theme ids (`LIGHT_THEME` / `DARK_THEME`); since `is:inline` scripts cannot import, `Layout.astro` passes them to the anti-flash script through a `data-theme-ids` attribute rather than hardcoding them
+- Theme switching lives entirely in `Header.astro` (dropdown, `Cmd/Ctrl + /` cycling, OS-preference sync) plus the inline anti-flash script in `Layout.astro`. `src/config/themes.ts` is the single source of theme ids (`LIGHT_THEME` / `DARK_THEME`); since `is:inline` scripts cannot import, `Layout.astro` passes them to the anti-flash script through `data-light` / `data-dark` attributes rather than hardcoding them
 - The scroll progress bar is pure CSS (`animation-timeline: scroll()` in `global.css`), decorative and `aria-hidden`. Browsers without scroll-driven animations simply do not show it
 - ESLint with TypeScript, Astro, and jsx-a11y plugins
 - External links in markdown open in new tabs (`rehype-external-links` in `astro.config.js`)

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -158,8 +158,6 @@ const currentPath = Astro.url.pathname;
   const OPTION_IDS = THEME_OPTIONS.map((t) => t.id);
   const ICON_BY_ID = Object.fromEntries(THEME_OPTIONS.map((t) => [t.id, t.iconId]));
 
-  const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T | null;
-
   function storedPreference(): string {
     const pref = localStorage.getItem('theme');
     return pref && OPTION_IDS.includes(pref) ? pref : 'auto';
@@ -197,8 +195,8 @@ const currentPath = Astro.url.pathname;
   });
 
   function toggleDropdown(show: boolean) {
-    const dropdown = $('theme-dropdown');
-    const toggle = $('theme-toggle');
+    const dropdown = document.getElementById('theme-dropdown');
+    const toggle = document.getElementById('theme-toggle');
     if (!dropdown || !toggle) return;
 
     dropdown.classList.toggle('opacity-0', !show);
@@ -208,8 +206,8 @@ const currentPath = Astro.url.pathname;
   }
 
   function setMobileMenu(open: boolean, returnFocus = true) {
-    const menu = $('mobile-menu');
-    const toggle = $('mobile-menu-toggle');
+    const menu = document.getElementById('mobile-menu');
+    const toggle = document.getElementById('mobile-menu-toggle');
     if (!menu || !toggle) return;
 
     menu.classList.toggle('hidden', !open);
@@ -220,14 +218,17 @@ const currentPath = Astro.url.pathname;
     else if (returnFocus) toggle.focus();
   }
 
-  const isMobileMenuOpen = () => !$('mobile-menu')?.classList.contains('hidden');
+  const isMobileMenuOpen = () =>
+    document.getElementById('mobile-menu')?.classList.contains('hidden') === false;
 
   document.addEventListener('click', (e) => {
     const target = e.target as HTMLElement;
 
     if (target.closest('#theme-toggle')) {
       e.preventDefault();
-      toggleDropdown($('theme-toggle')?.getAttribute('aria-expanded') !== 'true');
+      toggleDropdown(
+        document.getElementById('theme-toggle')?.getAttribute('aria-expanded') !== 'true'
+      );
       return;
     }
 
@@ -258,8 +259,8 @@ const currentPath = Astro.url.pathname;
 
     // Focus trap for the open mobile menu
     if (e.key === 'Tab' && isMobileMenuOpen()) {
-      const menu = $('mobile-menu');
-      const toggle = $('mobile-menu-toggle');
+      const menu = document.getElementById('mobile-menu');
+      const toggle = document.getElementById('mobile-menu-toggle');
       if (!menu || !toggle) return;
 
       const focusable = [toggle, ...menu.querySelectorAll<HTMLElement>('a, button')];

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -155,6 +155,8 @@ const currentPath = Astro.url.pathname;
 <script>
   import { THEME_OPTIONS, resolveTheme } from '../config/themes';
 
+  const $ = (id: string) => document.getElementById(id);
+
   const OPTION_IDS = THEME_OPTIONS.map((t) => t.id);
   const ICON_BY_ID = Object.fromEntries(THEME_OPTIONS.map((t) => [t.id, t.iconId]));
 
@@ -195,8 +197,8 @@ const currentPath = Astro.url.pathname;
   });
 
   function toggleDropdown(show: boolean) {
-    const dropdown = document.getElementById('theme-dropdown');
-    const toggle = document.getElementById('theme-toggle');
+    const dropdown = $('theme-dropdown');
+    const toggle = $('theme-toggle');
     if (!dropdown || !toggle) return;
 
     dropdown.classList.toggle('opacity-0', !show);
@@ -206,8 +208,8 @@ const currentPath = Astro.url.pathname;
   }
 
   function setMobileMenu(open: boolean, returnFocus = true) {
-    const menu = document.getElementById('mobile-menu');
-    const toggle = document.getElementById('mobile-menu-toggle');
+    const menu = $('mobile-menu');
+    const toggle = $('mobile-menu-toggle');
     if (!menu || !toggle) return;
 
     menu.classList.toggle('hidden', !open);
@@ -218,17 +220,14 @@ const currentPath = Astro.url.pathname;
     else if (returnFocus) toggle.focus();
   }
 
-  const isMobileMenuOpen = () =>
-    document.getElementById('mobile-menu')?.classList.contains('hidden') === false;
+  const isMobileMenuOpen = () => $('mobile-menu')?.classList.contains('hidden') === false;
 
   document.addEventListener('click', (e) => {
     const target = e.target as HTMLElement;
 
     if (target.closest('#theme-toggle')) {
       e.preventDefault();
-      toggleDropdown(
-        document.getElementById('theme-toggle')?.getAttribute('aria-expanded') !== 'true'
-      );
+      toggleDropdown($('theme-toggle')?.getAttribute('aria-expanded') !== 'true');
       return;
     }
 
@@ -259,8 +258,8 @@ const currentPath = Astro.url.pathname;
 
     // Focus trap for the open mobile menu
     if (e.key === 'Tab' && isMobileMenuOpen()) {
-      const menu = document.getElementById('mobile-menu');
-      const toggle = document.getElementById('mobile-menu-toggle');
+      const menu = $('mobile-menu');
+      const toggle = $('mobile-menu-toggle');
       if (!menu || !toggle) return;
 
       const focusable = [toggle, ...menu.querySelectorAll<HTMLElement>('a, button')];

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -27,19 +27,15 @@ const {
   publishedTime,
   tags,
 } = Astro.props;
-
-// `is:inline` cannot import, so the ids ride in on a data attribute instead of
-// being duplicated. config/themes.ts stays the single source.
-const themeIds = JSON.stringify({ light: LIGHT_THEME, dark: DARK_THEME });
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
     <!-- Theme initialization - must be first to prevent flash -->
-    <script is:inline data-theme-ids={themeIds}>
+    <script is:inline data-light={LIGHT_THEME} data-dark={DARK_THEME}>
       (function () {
-        const { light, dark } = JSON.parse(document.currentScript.dataset.themeIds);
+        const { light, dark } = document.currentScript.dataset;
 
         function theme() {
           const pref = localStorage.getItem('theme');

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -6,6 +6,7 @@ import Footer from './Footer.astro';
 import Head from './Head.astro';
 
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import { LIGHT_THEME, DARK_THEME } from '../config/themes';
 
 import '../styles/global.css';
 
@@ -26,19 +27,24 @@ const {
   publishedTime,
   tags,
 } = Astro.props;
+
+// `is:inline` cannot import, so the ids ride in on a data attribute instead of
+// being duplicated. config/themes.ts stays the single source.
+const themeIds = JSON.stringify({ light: LIGHT_THEME, dark: DARK_THEME });
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <!-- Theme initialization - must be first to prevent flash. Inlined (no imports
-         allowed here), so the two theme ids are duplicated from config/themes.ts. -->
-    <script is:inline>
+    <!-- Theme initialization - must be first to prevent flash -->
+    <script is:inline data-theme-ids={themeIds}>
       (function () {
+        const { light, dark } = JSON.parse(document.currentScript.dataset.themeIds);
+
         function theme() {
           const pref = localStorage.getItem('theme');
-          if (pref === 'cloud' || pref === 'cloud-dark') return pref;
-          return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'cloud-dark' : 'cloud';
+          if (pref === light || pref === dark) return pref;
+          return window.matchMedia('(prefers-color-scheme: dark)').matches ? dark : light;
         }
 
         document.documentElement.setAttribute('data-theme', theme());

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -3,7 +3,10 @@ import ExternalLinkIcon from '../../assets/icons/external-link.svg';
 
 type Project = {
   name: string;
+  /** GitHub repo URL, derived from `slug`. Always present. */
   url: string;
+  /** Live site, when the project has one. Primary link when set. */
+  homepage?: string;
   stars: number;
   featured: boolean;
   tagline: string;
@@ -39,23 +42,40 @@ const more = projects.filter((p) => !p.featured);
     <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
       {
         featured.map((project) => (
-          <article class="card card-lift group">
-            <a href={project.url} target="_blank" rel="noopener noreferrer" class="block p-6">
-              <h3 class="font-display font-semibold text-xl text-foreground mb-2 group-hover:text-accent transition-colors">
+          <article class="card card-lift group relative p-6">
+            <h3 class="font-display font-semibold text-xl text-foreground mb-2 group-hover:text-accent transition-colors">
+              <a
+                href={project.homepage ?? project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="stretched-link"
+              >
                 {project.name}
-              </h3>
-              <p class="text-foreground-secondary mb-4">{project.tagline}</p>
-              <div class="flex flex-wrap gap-2 mb-4">
-                {project.tech.map((t) => (
-                  <span class="tag">{t}</span>
-                ))}
-              </div>
+              </a>
+            </h3>
+            <p class="text-foreground-secondary mb-4">{project.tagline}</p>
+            <div class="flex flex-wrap gap-2 mb-4">
+              {project.tech.map((t) => (
+                <span class="tag">{t}</span>
+              ))}
+            </div>
+            <div class="flex items-center gap-4 font-mono text-xs text-foreground-tertiary">
               {project.stars > 0 && (
-                <span class="font-mono text-xs text-foreground-tertiary">
+                <span>
                   {project.stars} {project.stars === 1 ? 'star' : 'stars'}
                 </span>
               )}
-            </a>
+              {project.homepage && (
+                <a
+                  href={project.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="relative z-10 hover:text-accent-text transition-colors"
+                >
+                  GitHub
+                </a>
+              )}
+            </div>
           </article>
         ))
       }
@@ -66,7 +86,7 @@ const more = projects.filter((p) => !p.featured);
         <div class="mt-6 border-t border-line">
           {more.map((project) => (
             <a
-              href={project.url}
+              href={project.homepage ?? project.url}
               target="_blank"
               rel="noopener noreferrer"
               class="flex items-baseline justify-between gap-4 py-4 border-b border-line group"

--- a/src/components/home/ProjectsSection.astro
+++ b/src/components/home/ProjectsSection.astro
@@ -3,9 +3,7 @@ import ExternalLinkIcon from '../../assets/icons/external-link.svg';
 
 type Project = {
   name: string;
-  /** GitHub repo URL, derived from `slug`. Always present. */
   url: string;
-  /** Live site, when the project has one. Primary link when set. */
   homepage?: string;
   stars: number;
   featured: boolean;
@@ -42,40 +40,28 @@ const more = projects.filter((p) => !p.featured);
     <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
       {
         featured.map((project) => (
-          <article class="card card-lift group relative p-6">
-            <h3 class="font-display font-semibold text-xl text-foreground mb-2 group-hover:text-accent transition-colors">
-              <a
-                href={project.homepage ?? project.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="stretched-link"
-              >
+          <article class="card card-lift group">
+            <a
+              href={project.homepage ?? project.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="block p-6"
+            >
+              <h3 class="font-display font-semibold text-xl text-foreground mb-2 group-hover:text-accent transition-colors">
                 {project.name}
-              </a>
-            </h3>
-            <p class="text-foreground-secondary mb-4">{project.tagline}</p>
-            <div class="flex flex-wrap gap-2 mb-4">
-              {project.tech.map((t) => (
-                <span class="tag">{t}</span>
-              ))}
-            </div>
-            <div class="flex items-center gap-4 font-mono text-xs text-foreground-tertiary">
+              </h3>
+              <p class="text-foreground-secondary mb-4">{project.tagline}</p>
+              <div class="flex flex-wrap gap-2 mb-4">
+                {project.tech.map((t) => (
+                  <span class="tag">{t}</span>
+                ))}
+              </div>
               {project.stars > 0 && (
-                <span>
+                <span class="font-mono text-xs text-foreground-tertiary">
                   {project.stars} {project.stars === 1 ? 'star' : 'stars'}
                 </span>
               )}
-              {project.homepage && (
-                <a
-                  href={project.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="relative z-10 hover:text-accent-text transition-colors"
-                >
-                  GitHub
-                </a>
-              )}
-            </div>
+            </a>
           </article>
         ))
       }

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -5,19 +5,21 @@ type Theme = {
 };
 
 /**
- * Selectable options, in cycle order. `auto` follows the system preference.
- *
- * The ids `cloud` / `cloud-dark` are load-bearing: they are the `data-theme`
- * values, the localStorage payload, and the giscus theme mapping. Do not rename.
+ * The two `data-theme` values. Load-bearing: also the localStorage payload and
+ * the giscus theme mapping keys. Everything else derives from these.
  */
+export const LIGHT_THEME = 'cloud';
+export const DARK_THEME = 'cloud-dark';
+
+/** Selectable options, in cycle order. `auto` follows the system preference. */
 export const THEME_OPTIONS: Theme[] = [
   { id: 'auto', label: 'Auto', iconId: 'monitor' },
-  { id: 'cloud', label: 'Light', iconId: 'sun' },
-  { id: 'cloud-dark', label: 'Dark', iconId: 'moon' },
+  { id: LIGHT_THEME, label: 'Light', iconId: 'sun' },
+  { id: DARK_THEME, label: 'Dark', iconId: 'moon' },
 ];
 
 /** Map a stored preference to the `data-theme` value to apply. */
 export function resolveTheme(preference: string | null): string {
-  if (preference === 'cloud' || preference === 'cloud-dark') return preference;
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'cloud-dark' : 'cloud';
+  if (preference === LIGHT_THEME || preference === DARK_THEME) return preference;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? DARK_THEME : LIGHT_THEME;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,7 +35,7 @@ const projects = (await getCollection('projects'))
   .sort((a, b) => a.data.order - b.data.order)
   .map(({ data }) => ({
     ...data,
-    url: data.homepage ?? `${GITHUB_PROFILE_LINK}/${data.slug}`,
+    url: `${GITHUB_PROFILE_LINK}/${data.slug}`,
   }));
 ---
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -262,6 +262,14 @@
     border-color: var(--color-accent);
   }
 
+  /* Makes the whole positioned ancestor clickable, so a card can carry a
+     primary link plus a secondary one (which needs its own stacking context). */
+  .stretched-link::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+
   /* Button - Primary */
   .btn-primary {
     display: inline-flex;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -262,14 +262,6 @@
     border-color: var(--color-accent);
   }
 
-  /* Makes the whole positioned ancestor clickable, so a card can carry a
-     primary link plus a secondary one (which needs its own stacking context). */
-  .stretched-link::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-  }
-
   /* Button - Primary */
   .btn-primary {
     display: inline-flex;


### PR DESCRIPTION
Follow-up to #20, which traded the build-time GitHub API call for hand-maintained YAML. A code review found a few rough edges that came with it.

## Fixes

- **Single-source the theme ids.** `themes.ts` now exports `LIGHT_THEME` / `DARK_THEME`, and `Layout.astro` hands them to the inline anti-flash script via `data-light` / `data-dark` instead of hardcoding the literals. Renaming a theme no longer silently breaks first paint while everything still builds green.
- **Keep `homepage` and the repo URL distinct.** `url` is always the repo again; cards link to `homepage` when set. Previously the two collapsed into one field, so the repo URL was unrepresentable.
- **Fix `isMobileMenuOpen()`**, which reported "open" when `#mobile-menu` was absent (`!undefined === true`).
- **Drop the dead generic** on the `$` helper; its type parameter was never supplied.
- **Bump CI Node 22 → 24** to match the local toolchain.

## Not fixed

The removed slug-to-repo validation has no honest fix here. The old guard worked by checking the slug against the fetched repo list, and deleting that network call was the entire point of #20. A format regex would not catch a renamed repo, which is the failure that actually happens. If the coverage is wanted back, the right place is a link-checker step in CI against the built `dist/`. All four slugs currently resolve 200.

## Notes

The second commit walks back part of the first. The `homepage` fix initially came with a `.stretched-link` utility and a card restructure so a secondary repo link could sit alongside the primary one — roughly 28 lines of markup and CSS to expose one link on the single project that has a `homepage`. The finding was about the type, not the UX, so that part was cut.

## Verification

Build, `astro check`, ESLint, and Prettier all clean. Exercised in a real browser: theme resolution across `cloud` / `cloud-dark` / `auto` / junk / unset, dropdown selection, `Cmd+/` cycling, and the project card links.