### PR TITLE
Align site copy with AI agent systems positioning

### DIFF
--- a/content/projects/telegram-agent-kit.yml
+++ b/content/projects/telegram-agent-kit.yml
@@ -2,5 +2,5 @@ name: Telegram Agent Kit
 slug: telegram-agent-kit
 order: 2
 featured: true
-tagline: 'Runtime-agnostic ESM toolkit with a zero-dependency core, Markdown-to-HTML rendering, and live draft streaming for Telegram agents.'
+tagline: 'Runtime-agnostic ESM library that wires LLM agents to Telegram with a zero-dependency core, Markdown-to-HTML rendering, live draft streaming, and a turn-loop bridge over injectable Bot API interfaces.'
 tech: ['TypeScript', 'LLM agents', 'Telegram']

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -1,5 +1,5 @@
 ---
-import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../consts';
+import { AUTHOR_NAME, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../consts';
 ---
 
 <section class="hero" id="hero">
@@ -9,12 +9,12 @@ import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../..
       <div class="intro">
         <h1 class="hero-name">{AUTHOR_NAME}</h1>
         <p class="lead">
-          {ROLE} with 10+ years across React, TypeScript, and Node.js.
+          I design and build production systems around AI agents—and the infrastructure they run on.
         </p>
         <p class="sub">
-          I build the frontend for a large self-hosted product, and spend the rest of my time on
-          side projects, developer tools, and AI experiments. This is where I write about what I
-          learn along the way.
+          I bring 15+ years of production experience across frontend and full-stack development. My
+          focus includes agent runtimes, MCP servers, long-term memory layers, model routing and
+          failover, and Telegram and Discord integrations.
         </p>
         <div class="actions">
           <a href={`mailto:${MAIL_PROFILE_LINK}`} class="btn-primary">Get in touch</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,24 +2,33 @@
 import Layout from '../components/Layout.astro';
 import ExpertiseGrid from '../components/home/ExpertiseGrid.astro';
 
-import { ROLE, MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
+import { MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
 import { WORK_HISTORY, EXPERTISE, LOCATION } from '../config/resume';
 ---
 
-<Layout title="About" description="About Ivan Kalinichenko - Senior Frontend Engineer.">
+<Layout
+  title="About"
+  description="About Ivan Kalinichenko — AI agent systems, full-stack products, and frontend platforms."
+>
   <section class="py-14 md:py-20">
     <div class="container-prose">
       <h1 class="text-foreground mb-6">About</h1>
       <div class="space-y-4 text-foreground-secondary text-lg leading-relaxed">
         <p>
-          I'm a {ROLE.toLowerCase()} with 10+ years in the industry, from jQuery and Angular.js to modern
-          component architectures. That path shaped how I think about maintainable systems and team productivity.
+          I'm an engineer with 15+ years in production software, from jQuery and Angular.js to
+          modern React, TypeScript, and Node.js systems. That path shaped how I think about
+          maintainable architecture, safe migrations, and team productivity.
         </p>
         <p>
-          Today I build the frontend for a large-scale self-hosted product with React and
+          My main focus is AI infrastructure and agent systems: multi-agent runtimes, MCP servers,
+          long-term memory layers, model routing and failover, and Telegram and Discord
+          integrations. I also build the backend, frontend, infrastructure, and documentation
+          needed to turn those systems into products.
+        </p>
+        <p>
+          I currently build frontend systems for a large self-hosted product with React and
           TypeScript. Beyond writing code, I review merge requests, mentor frontend developers, run
-          technical interviews, and onboard new engineers. I use AI tools as part of the daily
-          workflow.
+          technical interviews, and onboard new engineers.
         </p>
         <p>
           Based in <span class="text-foreground">{LOCATION}</span>, working with international


### PR DESCRIPTION
Aligns the editable site copy with the canonical offer and recent public work.

- Replaces the outdated frontend-first, 10+ years hero with the verified 15+ years and AI agent systems focus.
- Expands the About introduction around agent infrastructure, full-stack product work, and frontend platforms while preserving current-role facts.
- Updates the Telegram Agent Kit tagline to include its turn-loop bridge and injectable Bot API boundary.

No unsupported outcomes or metrics are added.