### PR TITLE
Widen the blog to the wide track and unify post cards

### DIFF
--- a/.claude/skills/design-check/check-design.mjs
+++ b/.claude/skills/design-check/check-design.mjs
@@ -146,7 +146,9 @@ for (const [label, re] of forbidden) {
 console.log('\nTheme ids (must stay cloud / cloud-dark for giscus + localStorage):');
 const themes = readFileSync(THEMES, 'utf8');
 for (const id of ['cloud', 'cloud-dark']) {
-  const ok = new RegExp(`id:\\s*['"]${id}['"]`).test(themes);
+  // Matches the quoted literal anywhere in themes.ts: the ids live on the
+  // LIGHT_THEME / DARK_THEME constants, not on an `id:` property.
+  const ok = new RegExp(`['"]${id}['"]`).test(themes);
   if (!ok) hardFail++;
   line(ok, `id '${id}' present`);
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ Current order: Hero(default) → Selected work/Projects(default) → Writing(sub
 
 ## Containers & Fonts
 
-- Three container tracks in `global.css`: `.container` (wide, `--container-wide: 1100px`, used for header/footer and most sections), `.container-content` (content track, `--container-content: 820px`, used for the blog reading experience — post articles, the blog index, and tag pages), and `.container-prose` (tight reading column, `--container-prose: 680px`, used for the homepage intro text and `/about` bio).
+- Two container tracks in `global.css`: `.container` (wide, `--container-wide: 1100px`) is the default and covers header/footer, all sections, the post index pages (`/blog`, `/tags`, `/tags/<tag>`) and the blog post article; `.container-prose` (tight reading column, `--container-prose: 680px`) is only for the homepage intro text and the `/about` bio. The wide post body is a deliberate owner choice — don't narrow it back. (`.container-content`, the old 820px track, was removed once nothing used it.)
+- Post images are capped at 820px and centred inside the wide text column (`.prose-custom p > img` in `global.css`) so a screenshot stays a figure rather than a full-bleed banner.
+- Posts in a list render through `src/components/PostCard.astro` (pass `featured` for the lead card). Both `/blog` and `/tags/<tag>` use it — don't hand-roll a second row layout.
 - Font stack (configured via Astro's top-level `fonts` config in `astro.config.js`): Gambetta (display/headings), DM Sans (body), JetBrains Mono (code/mono accents).
 
 ## Key Patterns

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,8 +101,6 @@ components:
     padding: 2px 8px
   container-wide:
     width: 1100px
-  container-content:
-    width: 820px
   container-prose:
     width: 680px
 ---
@@ -129,9 +127,9 @@ gets out of its way without going invisible.
   (`data-theme="cloud-dark"`), plus `auto` (follows system). **Do not rename
   these ids** — the Giscus comment theme map and stored `localStorage`
   preferences depend on `cloud` / `cloud-dark`.
-- **Three width tracks:** a reading column (`.container-prose`, ~680px), a
-  wider content track for blog posts and post lists (`.container-content`,
-  ~820px), and a wide track (`.container`, ~1100px).
+- **Two width tracks:** a tight reading column (`.container-prose`, ~680px) and
+  a wide track (`.container`, ~1100px) used by everything else, including blog
+  posts.
 
 ## Colors
 
@@ -186,19 +184,25 @@ for AA; light primary buttons use white on `--color-accent-text`.
 
 ## Layout
 
-Three container tracks, applied by responsibility:
+Two container tracks, applied by responsibility:
 
-- `.container` — wide track, `--container-wide` ~1100px. Header, footer, the
-  homepage Selected-work grid, and any full-width block.
-- `.container-content` — content track, `--container-content` ~820px. The blog
-  reading experience: blog post article, blog index list, and tag pages
-  (`/tags` and `/tags/<tag>`). A roomier reading column than `.container-prose`.
+- `.container` — wide track, `--container-wide` ~1100px. The default. Header,
+  footer, the homepage Selected-work grid, the blog index and tag pages
+  (`/blog`, `/tags`, `/tags/<tag>`), the blog post article, and any full-width
+  block.
 - `.container-prose` — reading track, `--container-prose` ~680px. The tightest,
   most comfortable measure: homepage intro/writing text and `/about` bio.
 
-Reading content stays on a reading track (`.container-content` or
-`.container-prose`), never the wide track. Do not put an article on the wide
-track, and do not globally narrow the header/footer.
+The site is deliberately wide: the blog post article runs on the full ~1100px
+track, so the post body measure is long (~110 characters) rather than the
+classic 60-80. This is an owner decision, not an oversight. Do not "fix" it back
+to a narrow column. Do not globally narrow the header/footer.
+
+Standalone supporting paragraphs on a wide-track page (a page intro, a card
+description) still get `max-w-prose` so short copy does not stretch across the
+whole track. Post images are capped at 820px and centred inside the text column
+(`.prose-custom p > img`) so a screenshot reads as a figure, not a full-bleed
+banner.
 
 Sections use vertical rhythm `py-14 md:py-20`. Separate two adjacent
 default-background sections with `<hr class="divider" />` (an ornamental
@@ -252,9 +256,10 @@ scripts — no React/Motion in this project.
 
 **Do**
 
-- Put the blog reading experience (posts, post lists, tag pages) on
-  `.container-content` (~820px); tighter reading text (intro, `/about`) on
-  `.container-prose` (~680px); wide grids on `.container` (~1100px).
+- Default to `.container` (~1100px), including for the blog post article; use
+  `.container-prose` (~680px) only for the homepage intro and `/about` bio.
+- Render a post in a list with `PostCard.astro` (`featured` for the lead card)
+  rather than hand-rolling another row layout.
 - Use `--color-accent` for fills and `--color-accent-text` for small accent
   text/links (AA).
 - Keep the blog post body at the `prose` step (19px / 1.75); supporting text at

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,8 +39,7 @@ const socialLinks = [
           kalinichenko.dev
         </a>
         <p class="text-xs text-foreground-tertiary font-mono">
-          &copy; {currentYear}
-          {AUTHOR_NAME}. Built with Astro.
+          {`© ${currentYear} ${AUTHOR_NAME}. Built with Astro.`}
         </p>
       </div>
 

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,39 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { readingTime } from '../lib/reading-time';
+import { formatDate } from '../lib/format-date';
+
+type Props = {
+  post: CollectionEntry<'posts'>;
+  featured?: boolean;
+  class?: string;
+};
+
+const { post, featured = false, class: className } = Astro.props;
+---
+
+<article
+  class:list={['card card-lift group relative flex flex-col p-6', featured && 'md:p-8', className]}
+>
+  <a href={`/blog/${post.id}`} class="absolute inset-0" aria-label={post.data.title}></a>
+  <h2
+    class:list={[
+      'font-display font-semibold text-foreground mb-2 transition-colors group-hover:text-accent-text',
+      featured ? 'text-2xl md:text-3xl' : 'text-lg',
+    ]}
+  >
+    {post.data.title}
+  </h2>
+  <p
+    class:list={[
+      'text-foreground-secondary mb-4',
+      featured ? 'max-w-prose' : 'text-sm line-clamp-3',
+    ]}
+  >
+    {post.data.description}
+  </p>
+  <div class="mt-auto flex flex-wrap items-center gap-3 font-mono text-xs text-foreground-tertiary">
+    <span>{formatDate(post.data.pubDate)} · {readingTime(post.body ?? '')} min read</span>
+    {post.data.tags[0] && <span class="topic">{post.data.tags[0]}</span>}
+  </div>
+</article>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -5,15 +5,18 @@ import { formatDate } from '../lib/format-date';
 
 type Props = {
   post: CollectionEntry<'posts'>;
+  /** The lead card: spans the full grid width and gets the larger type. */
   featured?: boolean;
-  class?: string;
 };
 
-const { post, featured = false, class: className } = Astro.props;
+const { post, featured = false } = Astro.props;
 ---
 
 <article
-  class:list={['card card-lift group relative flex flex-col p-6', featured && 'md:p-8', className]}
+  class:list={[
+    'card card-lift group relative flex flex-col p-6',
+    featured && 'md:col-span-2 md:p-8',
+  ]}
 >
   <a href={`/blog/${post.id}`} class="absolute inset-0" aria-label={post.data.title}></a>
   <h2

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -73,7 +73,7 @@ const blogPostSchema = {
 >
   <script type="application/ld+json" is:inline set:html={JSON.stringify(blogPostSchema)} />
   <article class="py-12 md:py-16">
-    <div class="container-content">
+    <div class="container">
       <!-- Article Header -->
       <header class="mb-8">
         <!-- Back Link -->

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,9 +1,8 @@
 ---
 import { getCollection } from 'astro:content';
-import { readingTime } from '../../lib/reading-time';
-import { formatDate } from '../../lib/format-date';
 
 import Layout from '../../components/Layout.astro';
+import PostCard from '../../components/PostCard.astro';
 import RssIcon from '../../assets/icons/rss.svg';
 
 const allPosts = await getCollection('posts');
@@ -16,7 +15,7 @@ const [lead, ...rest] = posts;
   description="AI experiments, dev tools, frontend architecture, and things I'm figuring out along the way."
 >
   <section class="py-14 md:py-20">
-    <div class="container-content">
+    <div class="container">
       <div class="flex items-center gap-3 mb-3">
         <h1 class="text-foreground">Writing</h1>
         <a
@@ -28,53 +27,17 @@ const [lead, ...rest] = posts;
           <RssIcon class="w-5 h-5" />
         </a>
       </div>
-      <p class="text-foreground-secondary mb-10">
+      <p class="text-foreground-secondary mb-10 max-w-prose">
         AI experiments, dev tools, frontend architecture, and things I'm figuring out along the way.
       </p>
 
       {
         posts.length > 0 ? (
-          <div>
-            {lead && (
-              <a href={`/blog/${lead.id}`} class="block group mb-10">
-                <h2 class="font-display font-semibold text-2xl text-foreground mb-3 group-hover:text-accent transition-colors">
-                  {lead.data.title}
-                </h2>
-                <p class="text-foreground-secondary mb-3">{lead.data.description}</p>
-                <div class="flex items-center gap-3 font-mono text-xs text-foreground-tertiary">
-                  <span>
-                    {formatDate(lead.data.pubDate)} · {readingTime(lead.body ?? '')} min read
-                  </span>
-                  {lead.data.tags[0] && <span class="topic">{lead.data.tags[0]}</span>}
-                </div>
-              </a>
-            )}
-
-            {rest.length > 0 && (
-              <div class="border-t border-line">
-                {rest.map((post) => (
-                  <article class="group relative py-6 border-b border-line">
-                    <a
-                      href={`/blog/${post.id}`}
-                      class="absolute inset-0"
-                      aria-label={post.data.title}
-                    />
-                    <h2 class="font-display font-semibold text-lg text-foreground mb-1 group-hover:text-accent-text transition-colors">
-                      {post.data.title}
-                    </h2>
-                    <p class="text-foreground-secondary text-sm mb-2 line-clamp-2">
-                      {post.data.description}
-                    </p>
-                    <div class="flex items-center gap-3 font-mono text-xs text-foreground-tertiary">
-                      <span>
-                        {formatDate(post.data.pubDate)} · {readingTime(post.body ?? '')} min read
-                      </span>
-                      {post.data.tags[0] && <span class="topic">{post.data.tags[0]}</span>}
-                    </div>
-                  </article>
-                ))}
-              </div>
-            )}
+          <div class="grid gap-6 md:grid-cols-2">
+            {lead && <PostCard post={lead} featured class="md:col-span-2" />}
+            {rest.map((post) => (
+              <PostCard post={post} />
+            ))}
           </div>
         ) : (
           <p class="text-foreground-secondary">Articles coming soon.</p>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -34,7 +34,7 @@ const [lead, ...rest] = posts;
       {
         posts.length > 0 ? (
           <div class="grid gap-6 md:grid-cols-2">
-            {lead && <PostCard post={lead} featured class="md:col-span-2" />}
+            {lead && <PostCard post={lead} featured />}
             {rest.map((post) => (
               <PostCard post={post} />
             ))}

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -2,9 +2,8 @@
 import { getCollection } from 'astro:content';
 
 import Layout from '../../components/Layout.astro';
+import PostCard from '../../components/PostCard.astro';
 import ArrowLeftIcon from '../../assets/icons/arrow-left.svg';
-import { readingTime } from '../../lib/reading-time';
-import { formatDate } from '../../lib/format-date';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts');
@@ -23,11 +22,12 @@ export async function getStaticPaths() {
 
 const { tag } = Astro.params;
 const { posts } = Astro.props;
+const [lead, ...rest] = posts;
 ---
 
 <Layout title={`Posts tagged: ${tag}`} description={`All blog posts tagged with "${tag}".`}>
   <section class="py-14 md:py-20">
-    <div class="container-content">
+    <div class="container">
       <a
         href="/blog"
         class="inline-flex items-center gap-2 text-sm text-foreground-tertiary hover:text-foreground transition-colors mb-6"
@@ -40,25 +40,9 @@ const { posts } = Astro.props;
         <span class="topic">{posts.length} {posts.length === 1 ? 'post' : 'posts'}</span>
       </div>
 
-      <div class="border-t border-line mt-8">
-        {
-          posts.map((post) => (
-            <article class="group relative py-6 border-b border-line">
-              <a href={`/blog/${post.id}`} class="absolute inset-0" aria-label={post.data.title} />
-              <h2 class="font-display font-semibold text-lg text-foreground mb-1 group-hover:text-accent-text transition-colors">
-                {post.data.title}
-              </h2>
-              <p class="text-foreground-secondary text-sm mb-2 line-clamp-2">
-                {post.data.description}
-              </p>
-              <div class="flex items-center gap-3 font-mono text-xs text-foreground-tertiary">
-                <span>
-                  {formatDate(post.data.pubDate)} · {readingTime(post.body ?? '')} min read
-                </span>
-              </div>
-            </article>
-          ))
-        }
+      <div class="grid gap-6 md:grid-cols-2 mt-8">
+        {lead && <PostCard post={lead} featured class="md:col-span-2" />}
+        {rest.map((post) => <PostCard post={post} />)}
       </div>
     </div>
   </section>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -41,7 +41,7 @@ const [lead, ...rest] = posts;
       </div>
 
       <div class="grid gap-6 md:grid-cols-2 mt-8">
-        {lead && <PostCard post={lead} featured class="md:col-span-2" />}
+        {lead && <PostCard post={lead} featured />}
         {rest.map((post) => <PostCard post={post} />)}
       </div>
     </div>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -18,7 +18,7 @@ const tags = [...tagCounts.entries()].sort((a, b) => b[1] - a[1]);
 
 <Layout title="Tags" description="Browse all blog post tags.">
   <section class="py-14 md:py-20">
-    <div class="container-content">
+    <div class="container">
       <a
         href="/blog"
         class="inline-flex items-center gap-2 text-sm text-foreground-tertiary hover:text-foreground transition-colors mb-6"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -452,7 +452,6 @@
      figure inside the text, not a full-bleed break. */
   .prose-custom p > img {
     display: block;
-    height: auto;
     max-width: min(100%, 820px);
     margin-inline: auto;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -44,7 +44,6 @@
 
   /* Container */
   --container-wide: 1100px;
-  --container-content: 820px;
   --container-prose: 680px;
 }
 
@@ -219,16 +218,6 @@
     padding-right: var(--space-6);
   }
 
-  /* Content track (wider reading column for blog posts and post lists) */
-  .container-content {
-    width: 100%;
-    max-width: var(--container-content);
-    margin-left: auto;
-    margin-right: auto;
-    padding-left: var(--space-6);
-    padding-right: var(--space-6);
-  }
-
   /* Reading track */
   .container-prose {
     width: 100%;
@@ -241,7 +230,6 @@
 
   @media (min-width: 768px) {
     .container,
-    .container-content,
     .container-prose {
       padding-left: var(--space-8);
       padding-right: var(--space-8);
@@ -457,6 +445,16 @@
     border: 1px solid var(--color-border);
     border-radius: var(--radius-lg);
     margin: 2em 0;
+  }
+
+  /* The post body runs on the wide track, so an image left at full column width
+     reads as a banner. Cap it and centre it instead: a screenshot stays a
+     figure inside the text, not a full-bleed break. */
+  .prose-custom p > img {
+    display: block;
+    height: auto;
+    max-width: min(100%, 820px);
+    margin-inline: auto;
   }
 
   .prose-custom hr {


### PR DESCRIPTION
## What

The blog index, the tag pages and the post article all ran on the 820px content track. The index looked sparse and the post column felt cramped, so they all move to the 1100px wide track.

## Changes

- **Post lists are cards now.** `/blog` and `/tags/<tag>` render a lead feature card plus a 2-column grid. Both go through a new `PostCard.astro` instead of two near-identical hand-rolled row layouts.
- **Post article moves to `.container`.** The resulting body measure is long (~110 characters). That is a deliberate owner decision, and it is written down in `DESIGN.md` so a future pass does not "fix" it back to a narrow column.
- **Post images cap at 820px** and centre inside the text column, so a screenshot reads as a figure rather than a full-bleed banner.
- **`.container-content` deleted.** Nothing used it after the moves above, so the three container tracks become two (`.container` + `.container-prose`).

## Drive-by fixes

- Footer rendered `© 2026Ivan Kalinichenko`. Prettier had split `{currentYear}` and `{AUTHOR_NAME}` across lines and JSX collapses the newline between two expressions. Now a single template literal, so the formatter cannot reintroduce it.
- The `design-check` theme-id probe grepped for `id: 'cloud'` and had been failing on a clean tree ever since `themes.ts` moved to `LIGHT_THEME` / `DARK_THEME` constants. The gate was permanently red before this PR.

## Verification

- `npm run build`, `npm run lint`, `node .claude/skills/design-check/check-design.mjs` all green.
- Widths measured in the browser: header 1100 / article 1100 / text 1036 / image 820.
- No horizontal overflow at 375px; the card grid collapses to one column.
- Checked in both light and dark themes.

## Note

Not touched here: post markdown contains 24 em-dashes, which `DESIGN.md` bans in visible copy. The check script only scans `.astro` / `.ts`, so it does not reach `content/`. Happy to clean that up and widen the check in a follow-up.
