### PR TITLE
Switch headings to DM Sans and drop Gambetta

### DIFF
--- a/astro.config.js
+++ b/astro.config.js
@@ -34,13 +34,6 @@ export default defineConfig({
   },
   fonts: [
     {
-      provider: fontProviders.fontshare(),
-      name: 'Gambetta',
-      cssVariable: '--font-gambetta',
-      weights: [400, 500, 600],
-      fallbacks: ['Georgia', 'serif'],
-    },
-    {
       provider: fontProviders.google(),
       name: 'DM Sans',
       cssVariable: '--font-dm-sans',

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -62,7 +62,6 @@ const {
     />
 
     <!-- Fonts -->
-    <Font cssVariable="--font-gambetta" preload />
     <Font cssVariable="--font-dm-sans" preload />
     <Font cssVariable="--font-jetbrains-mono" preload />
   </head>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,7 +15,7 @@
 
 :root {
   /* Typography Scale - uses CSS variables from Astro font provider */
-  --font-display: var(--font-gambetta), Georgia, serif;
+  --font-display: var(--font-dm-sans), system-ui, sans-serif;
   --font-body: var(--font-dm-sans), system-ui, sans-serif;
   --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
 
@@ -71,10 +71,6 @@
   --color-accent-text: #a94a29;
 
   --color-code-bg: #ecebe5;
-
-  --font-display: var(--font-gambetta);
-  --font-body: var(--font-dm-sans);
-  --font-mono: var(--font-jetbrains-mono);
 }
 
 /* ============================================
@@ -100,10 +96,6 @@
   --color-accent-text: #e07a52;
 
   --color-code-bg: #202022;
-
-  --font-display: var(--font-gambetta);
-  --font-body: var(--font-dm-sans);
-  --font-mono: var(--font-jetbrains-mono);
 }
 
 /* ============================================


### PR DESCRIPTION
## What

Headings move from Gambetta (display serif) to DM Sans, the font already used for body text. Gambetta is removed entirely from `astro.config.js` and from the preload list in `Layout.astro`.

Hierarchy is now carried by weight (600) and tight tracking (-0.02em), which were already in place.

## Also

Removed the `--font-display` / `--font-body` / `--font-mono` declarations duplicated inside both theme blocks in `global.css`. They repeated the `:root` values verbatim and never differed between light and dark, so changing a font meant editing three places.

## Notes

- One less font request on every page.
- `DESIGN.md`, `CLAUDE.md` and `README.md` still describe Gambetta. Left as-is pending a decision on whether this stays; happy to update in a follow-up.

## Test plan

- [x] `npm run build` passes, 16 pages built
- [x] Visual check of headings on `/`, `/blog`, a post, and `/about` in both themes