### PR TITLE
Replace the hero spotlight with a site-wide pixel spotlight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,15 +74,19 @@ import VideoPlayer from '../../src/components/VideoPlayer.astro';
 
 Props: `src` (required), `caption` (required), `poster` (optional). Video is looped, muted, and plays inline. Click to play/pause. Uses a custom element for proper View Transitions lifecycle.
 
+### PixelSpotlight (`src/components/PixelSpotlight.astro`)
+
+The homepage cursor effect: a static 12px dot lattice plus a pixel-quantized terracotta glow that follows the pointer, both as fixed full-viewport layers at `z-index: -1`. Rendered once from `src/pages/index.astro`; no other page uses it. Its tint and cell fill are contrast-constrained — read the Interaction section of [`DESIGN.md`](./DESIGN.md) before turning either up.
+
 ### TableOfContents (`src/components/TableOfContents.astro`)
 
 Auto-generated from markdown headings (h2/h3) via Astro's `render()` `headings` array. Rendered once as an inline TOC above the article content in blog post pages (`src/pages/blog/[...id].astro`); it scrolls away naturally on the reading track. Active section tracking (an `IntersectionObserver` re-initialized on `astro:after-swap`) highlights the current heading's TOC link as the user scrolls. Headings use `scroll-margin-top` for proper anchor offset.
 
 ## Section Background Alternation
 
-Homepage sections no longer strictly alternate. Only the Writing section carries the subtle background (`bg-background-subtle`); the others use the default background. When adding or reordering sections, don't assume alternation — check each section's intent instead. Header and Footer both use `bg-background` (matching each other, distinct from sections).
+Homepage sections no longer strictly alternate. Only the Writing section carries the subtle background, and it is translucent (`bg-background-subtle/85`) so the homepage pixel field shows through; the others use the default background. When adding or reordering sections, don't assume alternation — check each section's intent instead. The Footer paints no background of its own and the Header is `bg-background/80` with a blur, both so the pixel field stays continuous — don't give either an opaque fill.
 
-Current order: Hero(default) → Selected work/Projects(default) → Writing(subtle) → Contact(default) → Footer(bg-background).
+Current order: Hero(default) → Selected work/Projects(default) → Writing(subtle, translucent) → Contact(default) → Footer(no fill).
 
 ## Containers & Fonts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Props: `src` (required), `caption` (required), `poster` (optional). Video is loo
 
 ### PixelSpotlight (`src/components/PixelSpotlight.astro`)
 
-The homepage cursor effect: a static 12px dot lattice plus a pixel-quantized terracotta glow that follows the pointer, both as fixed full-viewport layers at `z-index: -1`. Rendered once from `src/pages/index.astro`; no other page uses it. Its tint and cell fill are contrast-constrained — read the Interaction section of [`DESIGN.md`](./DESIGN.md) before turning either up.
+The site-wide cursor effect: a static 12px dot lattice plus a pixel-quantized terracotta glow that follows the pointer, both as fixed full-viewport layers at `z-index: -1`. Rendered once from `Layout.astro`, so every page carries it - don't add it per page. Its tint and cell fill are contrast-constrained — read the Interaction section of [`DESIGN.md`](./DESIGN.md) before turning either up.
 
 ### TableOfContents (`src/components/TableOfContents.astro`)
 
@@ -84,9 +84,9 @@ Auto-generated from markdown headings (h2/h3) via Astro's `render()` `headings` 
 
 ## Section Background Alternation
 
-Homepage sections no longer strictly alternate. Only the Writing section carries the subtle background, and it is translucent (`bg-background-subtle/85`) so the homepage pixel field shows through; the others use the default background. When adding or reordering sections, don't assume alternation — check each section's intent instead. The Footer paints no background of its own and the Header is `bg-background/80` with a blur, both so the pixel field stays continuous — don't give either an opaque fill.
+Homepage sections no longer strictly alternate. Only the Writing section carries the subtle background, and it is translucent (`bg-background-subtle/85`) so the pixel field shows through; the others use the default background. The same applies to the About page's Expertise band. Any new subtle section should use `/85` too, or it will punch a rectangular hole in the field. When adding or reordering sections, don't assume alternation — check each section's intent instead. The Footer keeps an opaque `bg-background` on purpose: it stops the pixel field so the page closes on a plain band. The Header is `bg-background/80` with a blur, so the field shows through it blurred.
 
-Current order: Hero(default) → Selected work/Projects(default) → Writing(subtle, translucent) → Contact(default) → Footer(no fill).
+Current order: Hero(default) → Selected work/Projects(default) → Writing(subtle, translucent) → Contact(default) → Footer(bg-background).
 
 ## Containers & Fonts
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -240,8 +240,8 @@ new one-off styles.
 
 Motion is restrained and always motivated (`MOTION_INTENSITY ~4`).
 
-- **Pixel spotlight** — homepage only (`PixelSpotlight.astro`, rendered once from
-  `index.astro`). Two fixed full-viewport layers at `z-index: -1`: a static dot
+- **Pixel spotlight** — site-wide (`PixelSpotlight.astro`, rendered once from
+  `Layout.astro`). Two fixed full-viewport layers at `z-index: -1`: a static dot
   lattice on a 12px grid that is always visible, and a terracotta radial glow
   that follows the cursor, quantized into squares by two striped masks combined
   with `mask-composite: intersect`. Vanilla JS (`pointermove`, rAF-throttled,
@@ -254,9 +254,16 @@ Motion is restrained and always motivated (`MOTION_INTENSITY ~4`).
   from, an `accent-text` link over a lit cell measures 3.9:1 against 5.1:1 on
   the bare background. Raising either number reopens that contrast hole.
 
-  Because the layer sits behind everything, any section that paints an opaque
-  background punches a hole in the lattice. That is why the Writing section uses
-  `bg-background-subtle/85` and the footer carries no background fill at all.
+  Because the layer sits behind everything, an opaque background hides it. Use
+  that deliberately, in one direction or the other:
+
+  - Sections that should let the field through use `bg-background-subtle/85`
+    rather than the flat token (the Writing section, the About page's Expertise
+    band). New subtle sections should follow suit.
+  - The footer keeps `bg-background` so the field stops there and the page
+    closes on a plain band.
+  - Cards stay opaque: they are meant to read as surfaces sitting on top of the
+    field.
 
 - **Hover underlines** — links/nav draw an accent underline on hover.
 - **Card lift** — subtle translate + tinted shadow on hover.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,7 +140,7 @@ both themes.
 
 - `--color-accent` (`#c25a34`) is the **bright fill** color. Use it for
   backgrounds, chip fills (via `color-mix`), the hover border on cards, the
-  divider mark, and the hero spotlight. Never use it for small text on a light
+  divider mark, and the page spotlight. Never use it for small text on a light
   background (it lands ~3.8:1 and fails WCAG AA).
 - `--color-accent-text` (`#a94a29` light / `#e07a52` dark) is the **AA-safe
   text** color. Use it for links, `.topic` chips, tag hover, and any small
@@ -240,10 +240,24 @@ new one-off styles.
 
 Motion is restrained and always motivated (`MOTION_INTENSITY ~4`).
 
-- **Hero spotlight** — a warm terracotta radial light follows the cursor across
-  the full hero width. Vanilla JS (`pointermove`, rAF-throttled, AbortController
-  cleanup, re-inits on `astro:after-swap`). Disabled under
-  `prefers-reduced-motion`.
+- **Pixel spotlight** — homepage only (`PixelSpotlight.astro`, rendered once from
+  `index.astro`). Two fixed full-viewport layers at `z-index: -1`: a static dot
+  lattice on a 12px grid that is always visible, and a terracotta radial glow
+  that follows the cursor, quantized into squares by two striped masks combined
+  with `mask-composite: intersect`. Vanilla JS (`pointermove`, rAF-throttled,
+  re-resolves its node on `astro:after-swap`, ignores `pointerType === 'touch'`).
+  Under `prefers-reduced-motion` the glow is dropped and the static lattice
+  stays.
+
+  The glow tint (18%) and the cell fill (45% of the cell) are held down
+  deliberately: the layer sits under body text, and at the 22% / 72% it started
+  from, an `accent-text` link over a lit cell measures 3.9:1 against 5.1:1 on
+  the bare background. Raising either number reopens that contrast hole.
+
+  Because the layer sits behind everything, any section that paints an opaque
+  background punches a hole in the lattice. That is why the Writing section uses
+  `bg-background-subtle/85` and the footer carries no background fill at all.
+
 - **Hover underlines** — links/nav draw an accent underline on hover.
 - **Card lift** — subtle translate + tinted shadow on hover.
 

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,8 +26,8 @@ const socialLinks = [
 ];
 ---
 
-<!-- no background fill: the body background shows through, and on the homepage so does the pixel field -->
-<footer class="border-t border-line">
+<!-- opaque on purpose: it hides the pixel field, so the footer reads as a plain close to the page -->
+<footer class="border-t border-line bg-background">
   <div class="container py-12 md:py-16">
     <!-- Main Footer Content -->
     <div class="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-6">

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,7 +26,8 @@ const socialLinks = [
 ];
 ---
 
-<footer class="border-t border-line bg-background">
+<!-- no background fill: the body background shows through, and on the homepage so does the pixel field -->
+<footer class="border-t border-line">
   <div class="container py-12 md:py-16">
     <!-- Main Footer Content -->
     <div class="grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-6">

--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -2,6 +2,7 @@
 import { Font } from 'astro:assets';
 
 import Header from './Header.astro';
+import PixelSpotlight from './PixelSpotlight.astro';
 import Footer from './Footer.astro';
 import Head from './Head.astro';
 
@@ -68,6 +69,8 @@ const {
   <body class="min-h-screen flex flex-col bg-background text-foreground antialiased">
     <!-- Scroll progress indicator: CSS scroll-driven, decorative (see global.css) -->
     <div class="scroll-progress" aria-hidden="true"></div>
+
+    <PixelSpotlight />
 
     <Header />
 

--- a/src/components/PixelSpotlight.astro
+++ b/src/components/PixelSpotlight.astro
@@ -1,0 +1,100 @@
+---
+// Page-wide cursor effect: a static dot lattice always visible, plus a warm
+// accent glow quantized into pixels that follows the cursor. Homepage only.
+// See DESIGN.md > Interaction.
+---
+
+<div class="pixel-fx" aria-hidden="true">
+  <div class="fx-dots"></div>
+  <div class="fx-glow"></div>
+</div>
+
+<style>
+  .pixel-fx {
+    position: fixed;
+    inset: 0;
+    z-index: -1; /* above the body background, under every section */
+    pointer-events: none;
+    --cell: 12px;
+    --mx: 50vw;
+    --my: 50vh;
+  }
+  .pixel-fx > * {
+    position: absolute;
+    inset: 0;
+  }
+
+  .fx-dots {
+    background-image: radial-gradient(circle at center, var(--color-line) 1.2px, transparent 1.2px);
+    background-size: var(--cell) var(--cell);
+  }
+
+  .fx-glow {
+    opacity: 0;
+    transition: opacity 0.32s ease;
+    background: radial-gradient(
+      340px circle at var(--mx) var(--my),
+      color-mix(in srgb, var(--color-accent) 18%, transparent),
+      transparent 70%
+    );
+    /* Square lattice: two striped masks intersected, so only the cells survive.
+       Fill and tint are held down on purpose: the glow lands under body text,
+       and a denser field drops accent links below AA (see DESIGN.md). */
+    --fill: calc(var(--cell) * 0.45);
+    mask-image:
+      repeating-linear-gradient(to right, #000 0 var(--fill), transparent var(--fill) var(--cell)),
+      repeating-linear-gradient(to bottom, #000 0 var(--fill), transparent var(--fill) var(--cell));
+    mask-composite: intersect;
+  }
+  .pixel-fx[data-lit] .fx-glow {
+    opacity: 1;
+  }
+
+  /* the lattice is static, so it stays; only the cursor glow is motion */
+  @media (prefers-reduced-motion: reduce) {
+    .fx-glow {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  let fx: HTMLElement | null = null;
+  let raf = 0;
+  let x = 0;
+  let y = 0;
+
+  // ClientRouter keeps this module alive across swaps, so re-resolve the node
+  // and let the listeners no-op on pages that don't render the layer.
+  function bind() {
+    fx = document.querySelector<HTMLElement>('.pixel-fx');
+  }
+
+  if (!matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    addEventListener(
+      'pointermove',
+      (e) => {
+        if (!fx || e.pointerType === 'touch') return;
+        x = e.clientX;
+        y = e.clientY;
+        if (raf) return;
+        raf = requestAnimationFrame(() => {
+          if (fx) {
+            fx.style.setProperty('--mx', `${x}px`);
+            fx.style.setProperty('--my', `${y}px`);
+            fx.dataset.lit = '';
+          }
+          raf = 0;
+        });
+      },
+      { passive: true }
+    );
+
+    document.addEventListener('pointerleave', () => {
+      if (fx) delete fx.dataset.lit;
+    });
+  }
+
+  bind();
+  document.addEventListener('astro:after-swap', bind);
+</script>

--- a/src/components/PixelSpotlight.astro
+++ b/src/components/PixelSpotlight.astro
@@ -1,7 +1,7 @@
 ---
-// Page-wide cursor effect: a static dot lattice always visible, plus a warm
-// accent glow quantized into pixels that follows the cursor. Homepage only.
-// See DESIGN.md > Interaction.
+// Site-wide cursor effect: a static dot lattice always visible, plus a warm
+// accent glow quantized into pixels that follows the cursor. Rendered once by
+// Layout.astro, so every page carries it. See DESIGN.md > Interaction.
 ---
 
 <div class="pixel-fx" aria-hidden="true">

--- a/src/components/PixelSpotlight.astro
+++ b/src/components/PixelSpotlight.astro
@@ -5,7 +5,6 @@
 ---
 
 <div class="pixel-fx" aria-hidden="true">
-  <div class="fx-dots"></div>
   <div class="fx-glow"></div>
 </div>
 
@@ -16,20 +15,13 @@
     z-index: -1; /* above the body background, under every section */
     pointer-events: none;
     --cell: 12px;
-    --mx: 50vw;
-    --my: 50vh;
-  }
-  .pixel-fx > * {
-    position: absolute;
-    inset: 0;
-  }
-
-  .fx-dots {
     background-image: radial-gradient(circle at center, var(--color-line) 1.2px, transparent 1.2px);
     background-size: var(--cell) var(--cell);
   }
 
   .fx-glow {
+    position: absolute;
+    inset: 0;
     opacity: 0;
     transition: opacity 0.32s ease;
     background: radial-gradient(
@@ -37,16 +29,15 @@
       color-mix(in srgb, var(--color-accent) 18%, transparent),
       transparent 70%
     );
-    /* Square lattice: two striped masks intersected, so only the cells survive.
-       Fill and tint are held down on purpose: the glow lands under body text,
-       and a denser field drops accent links below AA (see DESIGN.md). */
+    /* Square lattice: two striped masks intersected. Tint and fill are held
+       down for contrast, see DESIGN.md > Interaction before raising either. */
     --fill: calc(var(--cell) * 0.45);
     mask-image:
       repeating-linear-gradient(to right, #000 0 var(--fill), transparent var(--fill) var(--cell)),
       repeating-linear-gradient(to bottom, #000 0 var(--fill), transparent var(--fill) var(--cell));
     mask-composite: intersect;
   }
-  .pixel-fx[data-lit] .fx-glow {
+  :root[data-lit] .fx-glow {
     opacity: 1;
   }
 
@@ -59,42 +50,31 @@
 </style>
 
 <script>
-  let fx: HTMLElement | null = null;
-  let raf = 0;
-  let x = 0;
-  let y = 0;
-
-  // ClientRouter keeps this module alive across swaps, so re-resolve the node
-  // and let the listeners no-op on pages that don't render the layer.
-  function bind() {
-    fx = document.querySelector<HTMLElement>('.pixel-fx');
-  }
-
+  // Written to <html>, not to the layer: custom properties inherit, and
+  // ClientRouter replaces the layer on every swap while the root survives.
   if (!matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    const root = document.documentElement;
+    let raf = 0;
+    let x = 0;
+    let y = 0;
+
     addEventListener(
       'pointermove',
       (e) => {
-        if (!fx || e.pointerType === 'touch') return;
+        if (e.pointerType === 'touch') return;
         x = e.clientX;
         y = e.clientY;
         if (raf) return;
         raf = requestAnimationFrame(() => {
-          if (fx) {
-            fx.style.setProperty('--mx', `${x}px`);
-            fx.style.setProperty('--my', `${y}px`);
-            fx.dataset.lit = '';
-          }
+          root.style.setProperty('--mx', `${x}px`);
+          root.style.setProperty('--my', `${y}px`);
+          root.dataset.lit = '';
           raf = 0;
         });
       },
       { passive: true }
     );
 
-    document.addEventListener('pointerleave', () => {
-      if (fx) delete fx.dataset.lit;
-    });
+    document.addEventListener('pointerleave', () => delete root.dataset.lit);
   }
-
-  bind();
-  document.addEventListener('astro:after-swap', bind);
 </script>

--- a/src/components/home/BlogSection.astro
+++ b/src/components/home/BlogSection.astro
@@ -13,7 +13,8 @@ const { latestPosts } = Astro.props;
 const [lead, ...rest] = latestPosts;
 ---
 
-<section id="writing" class="py-14 md:py-20 bg-background-subtle">
+<!-- translucent so the homepage pixel field runs through instead of stopping dead here -->
+<section id="writing" class="py-14 md:py-20 bg-background-subtle/85">
   <div class="container">
     <div class="flex items-end justify-between gap-4 mb-8">
       <h2 class="text-foreground">Writing</h2>

--- a/src/components/home/BlogSection.astro
+++ b/src/components/home/BlogSection.astro
@@ -13,7 +13,6 @@ const { latestPosts } = Astro.props;
 const [lead, ...rest] = latestPosts;
 ---
 
-<!-- translucent so the homepage pixel field runs through instead of stopping dead here -->
 <section id="writing" class="py-14 md:py-20 bg-background-subtle/85">
   <div class="container">
     <div class="flex items-end justify-between gap-4 mb-8">

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -4,29 +4,26 @@ import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../..
 
 <section class="hero" id="hero">
   <div class="container">
-    <div class="hero-inner">
-      <div class="spotlight" aria-hidden="true"></div>
-      <div class="intro">
-        <h1 class="hero-name">{AUTHOR_NAME}</h1>
-        <p class="lead">
-          {ROLE} with 10+ years across React, TypeScript, and Node.js.
-        </p>
-        <p class="sub">
-          I build the frontend for a large self-hosted product, and spend the rest of my time on
-          side projects, developer tools, and AI experiments. This is where I write about what I
-          learn along the way.
-        </p>
-        <div class="actions">
-          <a href={`mailto:${MAIL_PROFILE_LINK}`} class="btn-primary">Get in touch</a>
-          <a
-            href={GITHUB_PROFILE_LINK}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="btn-secondary"
-          >
-            GitHub
-          </a>
-        </div>
+    <div class="intro">
+      <h1 class="hero-name">{AUTHOR_NAME}</h1>
+      <p class="lead">
+        {ROLE} with 10+ years across React, TypeScript, and Node.js.
+      </p>
+      <p class="sub">
+        I build the frontend for a large self-hosted product, and spend the rest of my time on side
+        projects, developer tools, and AI experiments. This is where I write about what I learn
+        along the way.
+      </p>
+      <div class="actions">
+        <a href={`mailto:${MAIL_PROFILE_LINK}`} class="btn-primary">Get in touch</a>
+        <a
+          href={GITHUB_PROFILE_LINK}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn-secondary"
+        >
+          GitHub
+        </a>
       </div>
     </div>
   </div>
@@ -37,12 +34,7 @@ import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../..
     padding-top: var(--space-16);
     padding-bottom: var(--space-8);
   }
-  .hero-inner {
-    position: relative;
-  }
   .intro {
-    position: relative;
-    z-index: 1;
     max-width: var(--container-prose);
   }
   .hero-name {
@@ -66,68 +58,4 @@ import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../..
     gap: var(--space-3);
     align-items: center;
   }
-
-  /* signature: warm cursor spotlight across the full hero width */
-  .spotlight {
-    position: absolute;
-    inset: -28px -24px;
-    z-index: 0;
-    pointer-events: none;
-    border-radius: 28px;
-    opacity: 0;
-    transition: opacity 0.32s ease;
-    background: radial-gradient(
-      340px circle at var(--mx, 50%) var(--my, 50%),
-      color-mix(in srgb, var(--color-accent) 22%, transparent),
-      transparent 70%
-    );
-  }
-  .hero-inner:hover .spotlight {
-    opacity: 1;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .spotlight {
-      display: none;
-    }
-  }
 </style>
-
-<script>
-  function initHeroSpotlight() {
-    const hero = document.querySelector<HTMLElement>('#hero .hero-inner');
-    const spot = document.querySelector<HTMLElement>('#hero .spotlight');
-    if (!hero || !spot) return;
-
-    type El = HTMLElement & { __spotCleanup?: () => void };
-    const el = hero as El;
-    if (el.__spotCleanup) el.__spotCleanup();
-
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
-
-    const controller = new AbortController();
-    el.__spotCleanup = () => controller.abort();
-
-    let raf = 0;
-    let mx = 0;
-    let my = 0;
-    hero.addEventListener(
-      'pointermove',
-      (e) => {
-        const r = hero.getBoundingClientRect();
-        mx = e.clientX - r.left;
-        my = e.clientY - r.top;
-        if (!raf) {
-          raf = requestAnimationFrame(() => {
-            spot.style.setProperty('--mx', `${mx}px`);
-            spot.style.setProperty('--my', `${my}px`);
-            raf = 0;
-          });
-        }
-      },
-      { signal: controller.signal }
-    );
-  }
-
-  initHeroSpotlight();
-  document.addEventListener('astro:after-swap', initHeroSpotlight);
-</script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -41,7 +41,6 @@ import { WORK_HISTORY, EXPERTISE, LOCATION } from '../config/resume';
     </div>
   </section>
 
-  <!-- translucent so the pixel field runs through instead of stopping dead here -->
   <section class="py-14 md:py-20 bg-background-subtle/85">
     <div class="container">
       <h2 class="text-foreground mb-8">Expertise</h2>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -41,7 +41,8 @@ import { WORK_HISTORY, EXPERTISE, LOCATION } from '../config/resume';
     </div>
   </section>
 
-  <section class="py-14 md:py-20 bg-background-subtle">
+  <!-- translucent so the pixel field runs through instead of stopping dead here -->
+  <section class="py-14 md:py-20 bg-background-subtle/85">
     <div class="container">
       <h2 class="text-foreground mb-8">Expertise</h2>
       <ExpertiseGrid expertise={EXPERTISE} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 
 import Layout from '../components/Layout.astro';
+import PixelSpotlight from '../components/PixelSpotlight.astro';
 import HeroSection from '../components/home/HeroSection.astro';
 import ProjectsSection from '../components/home/ProjectsSection.astro';
 import BlogSection from '../components/home/BlogSection.astro';
@@ -41,6 +42,7 @@ const projects = (await getCollection('projects'))
 
 <Layout>
   <script type="application/ld+json" is:inline set:html={JSON.stringify(personSchema)} />
+  <PixelSpotlight />
   <HeroSection />
   <div class="container"><hr class="divider" /></div>
   <ProjectsSection projects={projects} githubProfileLink={GITHUB_PROFILE_LINK} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,6 @@
 import { getCollection } from 'astro:content';
 
 import Layout from '../components/Layout.astro';
-import PixelSpotlight from '../components/PixelSpotlight.astro';
 import HeroSection from '../components/home/HeroSection.astro';
 import ProjectsSection from '../components/home/ProjectsSection.astro';
 import BlogSection from '../components/home/BlogSection.astro';
@@ -42,7 +41,6 @@ const projects = (await getCollection('projects'))
 
 <Layout>
   <script type="application/ld+json" is:inline set:html={JSON.stringify(personSchema)} />
-  <PixelSpotlight />
   <HeroSection />
   <div class="container"><hr class="divider" /></div>
   <ProjectsSection projects={projects} githubProfileLink={GITHUB_PROFILE_LINK} />


### PR DESCRIPTION
## Summary

The cursor light used to live inside the hero and only appear on hover. It now runs on every page and reads as pixels:

- a static 12px dot lattice, always visible (so it is there on touch devices and under `prefers-reduced-motion` too)
- a terracotta radial glow that follows the cursor, quantized into squares by two striped masks combined with `mask-composite: intersect`

Both are one fixed layer at `z-index: -1`, rendered once from `Layout.astro`. The old `.spotlight` markup, styles, and script are gone from `HeroSection.astro`.

The cursor position is written to `<html>` rather than to the layer: custom properties inherit down to it, and the document element survives ClientRouter swaps, so there is no node lookup and no rebind on navigation.

## Section backgrounds

An opaque background hides the layer, which makes it a deliberate tool in both directions:

- The Writing section and the About page's Expertise band drop to `bg-background-subtle/85` so the field runs through them instead of leaving a rectangular hole.
- The footer keeps its opaque `bg-background`, so the field stops there and the page closes on a plain band.
- Cards stay opaque: they should read as surfaces sitting on top of the field.

## Contrast

The effect started at 22% tint with a 72% cell fill. That version put a dense orange field under body text: an `accent-text` link over a lit cell measures **3.9:1**, against 5.1:1 on the bare background, so it broke the AA rule in DESIGN.md. Shipping at 18% / 45% instead, which keeps the pixel character while leaving mostly bare background under the glyphs. Both numbers and the reasoning are recorded in DESIGN.md so they don't get quietly turned back up.

## Test plan

- Light and dark themes: hero, the dense project rows, `/blog`, `/about`, `/tags`, and a post with the cursor parked over a paragraph
- ClientRouter navigation home → /blog → home: the glow re-lights and `data-theme` survives
- `npm run lint` and `npm run build` clean