### PR TITLE
Align site copy with AI agent systems positioning

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -1,5 +1,5 @@
 ---
-import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../consts';
+import { AUTHOR_NAME, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../consts';
 ---
 
 <section class="hero" id="hero">
@@ -7,12 +7,12 @@ import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../..
     <div class="intro">
       <h1 class="hero-name">{AUTHOR_NAME}</h1>
       <p class="lead">
-        {ROLE} with 10+ years across React, TypeScript, and Node.js.
+        I design and build production systems around AI agents—and the infrastructure they run on.
       </p>
       <p class="sub">
-        I build the frontend for a large self-hosted product, and spend the rest of my time on side
-        projects, developer tools, and AI experiments. This is where I write about what I learn
-        along the way.
+        I bring 15+ years in frontend and full-stack development. I currently build the React and
+        TypeScript frontend for a large self-hosted product. Outside that role, I build agent
+        infrastructure, developer tools, and products from idea to production.
       </p>
       <div class="actions">
         <a href={`mailto:${MAIL_PROFILE_LINK}`} class="btn-primary">Get in touch</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,24 +2,29 @@
 import Layout from '../components/Layout.astro';
 import ExpertiseGrid from '../components/home/ExpertiseGrid.astro';
 
-import { ROLE, MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
+import { MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
 import { WORK_HISTORY, EXPERTISE, LOCATION } from '../config/resume';
 ---
 
-<Layout title="About" description="About Ivan Kalinichenko - Senior Frontend Engineer.">
+<Layout title="About" description="About Ivan Kalinichenko — AI agent systems and full-stack engineering.">
   <section class="py-14 md:py-20">
     <div class="container-prose">
       <h1 class="text-foreground mb-6">About</h1>
       <div class="space-y-4 text-foreground-secondary text-lg leading-relaxed">
         <p>
-          I'm a {ROLE.toLowerCase()} with 10+ years in the industry, from jQuery and Angular.js to modern
-          component architectures. That path shaped how I think about maintainable systems and team productivity.
+          I design and build production systems around AI agents and the infrastructure they run
+          on. My work includes multi-agent runtimes, MCP servers, long-term agent memory, model
+          routing and failover, and Telegram integrations.
+        </p>
+        <p>
+          I bring 15+ years in production software, from jQuery and AngularJS to modern React and
+          TypeScript systems. I also take products from idea to production across backend,
+          frontend, infrastructure, billing, privacy, and documentation.
         </p>
         <p>
           Today I build the frontend for a large-scale self-hosted product with React and
           TypeScript. Beyond writing code, I review merge requests, mentor frontend developers, run
-          technical interviews, and onboard new engineers. I use AI tools as part of the daily
-          workflow.
+          technical interviews, and onboard new engineers.
         </p>
         <p>
           Based in <span class="text-foreground">{LOCATION}</span>, working with international


### PR DESCRIPTION
Align the home page and About copy with the positioning already used in the GitHub profile.

- lead with production AI agent systems
- replace the stale 10+ years claim with 15+
- keep current frontend work and broader full-stack experience as supporting evidence
- update the About meta description

No layout or styling changes.