### PR TITLE
Align site copy with current agentic AI work

### DIFF
--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -6,13 +6,10 @@ import { AUTHOR_NAME, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../const
   <div class="container">
     <div class="intro">
       <h1 class="hero-name">{AUTHOR_NAME}</h1>
-      <p class="lead">
-        I design and build production systems around AI agents—and the infrastructure they run on.
-      </p>
+      <p class="lead">I build AI agent systems and the infrastructure they run on.</p>
       <p class="sub">
-        I bring 15+ years in frontend and full-stack development. Since late 2025, I have worked
-        intensively with Claude Code and Codex. Since February 2026, my work has focused on building
-        new products with agentic workflows and developing AI infrastructure.
+        15+ years of production experience in frontend and full-stack development. Today I build
+        new products with agentic workflows and develop the infrastructure behind them.
       </p>
       <div class="actions">
         <a href={`mailto:${MAIL_PROFILE_LINK}`} class="btn-primary">Get in touch</a>

--- a/src/components/home/HeroSection.astro
+++ b/src/components/home/HeroSection.astro
@@ -1,5 +1,5 @@
 ---
-import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../consts';
+import { AUTHOR_NAME, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../../consts';
 ---
 
 <section class="hero" id="hero">
@@ -7,12 +7,12 @@ import { AUTHOR_NAME, ROLE, MAIL_PROFILE_LINK, GITHUB_PROFILE_LINK } from '../..
     <div class="intro">
       <h1 class="hero-name">{AUTHOR_NAME}</h1>
       <p class="lead">
-        {ROLE} with 10+ years across React, TypeScript, and Node.js.
+        I design and build production systems around AI agents—and the infrastructure they run on.
       </p>
       <p class="sub">
-        I build the frontend for a large self-hosted product, and spend the rest of my time on side
-        projects, developer tools, and AI experiments. This is where I write about what I learn
-        along the way.
+        I bring 15+ years in frontend and full-stack development. Since late 2025, I have worked
+        intensively with Claude Code and Codex. Since February 2026, my work has focused on building
+        new products with agentic workflows and developing AI infrastructure.
       </p>
       <div class="actions">
         <a href={`mailto:${MAIL_PROFILE_LINK}`} class="btn-primary">Get in touch</a>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,29 +6,29 @@ import { MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
 import { WORK_HISTORY, EXPERTISE, LOCATION } from '../config/resume';
 ---
 
-<Layout title="About" description="About Ivan Kalinichenko — AI agent systems and full-stack engineering.">
+<Layout title="About" description="About Ivan Kalinichenko — AI agent infrastructure and full-stack engineering.">
   <section class="py-14 md:py-20">
     <div class="container-prose">
       <h1 class="text-foreground mb-6">About</h1>
       <div class="space-y-4 text-foreground-secondary text-lg leading-relaxed">
         <p>
-          I design and build production systems around AI agents and the infrastructure they run
-          on. My work includes agent runtimes, MCP servers, tools, harnesses, long-term memory,
-          model routing and failover, and chat integrations.
+          My current work is AI agent infrastructure: multi-agent runtimes and harnesses, MCP
+          servers and agent tools, long-term agent memory, model routing and failover, and Telegram
+          and Discord integrations.
         </p>
         <p>
-          I bring 15+ years in production software, from jQuery and AngularJS to modern React and
-          TypeScript systems. I also take products from idea to production across backend,
-          frontend, infrastructure, billing, privacy, and documentation.
+          Since late 2025, I've worked daily with agentic coding tools, mainly Claude Code and
+          Codex. Since February 2026, my work has focused on new products built with these workflows
+          and on AI agent infrastructure.
         </p>
         <p>
-          Since late 2025, I have worked intensively with agentic coding tools, especially Claude
-          Code and Codex. Since February 2026, my work has focused entirely on building new products
-          with these workflows and developing AI infrastructure.
+          My background spans 15+ years of production software, from jQuery and AngularJS to React
+          and TypeScript. I've taken products from idea to production end to end: backend, frontend,
+          infrastructure, billing, email deliverability, GDPR/privacy, and documentation.
         </p>
         <p>
-          Based in <span class="text-foreground">{LOCATION}</span>, working with international
-          remote teams.
+          Based in <span class="text-foreground">{LOCATION}</span> (UTC+4), working remotely with
+          international teams.
         </p>
       </div>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,24 +2,29 @@
 import Layout from '../components/Layout.astro';
 import ExpertiseGrid from '../components/home/ExpertiseGrid.astro';
 
-import { ROLE, MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
+import { MAIL_PROFILE_LINK, LINKEDIN_PROFILE_LINK } from '../consts';
 import { WORK_HISTORY, EXPERTISE, LOCATION } from '../config/resume';
 ---
 
-<Layout title="About" description="About Ivan Kalinichenko - Senior Frontend Engineer.">
+<Layout title="About" description="About Ivan Kalinichenko — AI agent systems and full-stack engineering.">
   <section class="py-14 md:py-20">
     <div class="container-prose">
       <h1 class="text-foreground mb-6">About</h1>
       <div class="space-y-4 text-foreground-secondary text-lg leading-relaxed">
         <p>
-          I'm a {ROLE.toLowerCase()} with 10+ years in the industry, from jQuery and Angular.js to modern
-          component architectures. That path shaped how I think about maintainable systems and team productivity.
+          I design and build production systems around AI agents and the infrastructure they run
+          on. My work includes agent runtimes, MCP servers, tools, harnesses, long-term memory,
+          model routing and failover, and chat integrations.
         </p>
         <p>
-          Today I build the frontend for a large-scale self-hosted product with React and
-          TypeScript. Beyond writing code, I review merge requests, mentor frontend developers, run
-          technical interviews, and onboard new engineers. I use AI tools as part of the daily
-          workflow.
+          I bring 15+ years in production software, from jQuery and AngularJS to modern React and
+          TypeScript systems. I also take products from idea to production across backend,
+          frontend, infrastructure, billing, privacy, and documentation.
+        </p>
+        <p>
+          Since late 2025, I have worked intensively with agentic coding tools, especially Claude
+          Code and Codex. Since February 2026, my work has focused entirely on building new products
+          with these workflows and developing AI infrastructure.
         </p>
         <p>
           Based in <span class="text-foreground">{LOCATION}</span>, working with international


### PR DESCRIPTION
Supersedes PR #30 with corrected current-role wording.

- leads with production AI agent systems
- notes intensive Claude Code and Codex use since late 2025
- reflects the February 2026 shift away from the large self-hosted legacy React product
- describes current work as new product development with agentic workflows and AI infrastructure
- keeps 15+ years of frontend and full-stack experience as supporting context

No layout or styling changes.

PR #30 could not be updated directly because its branch was not opened by this agent.