### PR TITLE
docs: drop stale Gambetta, jsx-a11y and Octokit references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Current order: Hero(default) → Selected work/Projects(default) → Writing(sub
 - Two container tracks in `global.css`: `.container` (wide, `--container-wide: 1100px`) is the default and covers header/footer, all sections, the post index pages (`/blog`, `/tags`, `/tags/<tag>`) and the blog post article; `.container-prose` (tight reading column, `--container-prose: 680px`) is only for the homepage intro text and the `/about` bio. The wide post body is a deliberate owner choice — don't narrow it back. (`.container-content`, the old 820px track, was removed once nothing used it.)
 - Post images are capped at 820px and centred inside the wide text column (`.prose-custom p > img` in `global.css`) so a screenshot stays a figure rather than a full-bleed banner.
 - Posts in a list render through `src/components/PostCard.astro` (pass `featured` for the lead card). Both `/blog` and `/tags/<tag>` use it — don't hand-roll a second row layout.
-- Font stack (configured via Astro's top-level `fonts` config in `astro.config.js`): Gambetta (display/headings), DM Sans (body), JetBrains Mono (code/mono accents).
+- Font stack (configured via Astro's top-level `fonts` config in `astro.config.js`): DM Sans (headings and body, via both `--font-display` and `--font-body`), JetBrains Mono (code/mono accents). Only two families load; headings separate from body by size, weight and tracking, not by a second face.
 
 ## Key Patterns
 
@@ -104,6 +104,6 @@ Current order: Hero(default) → Selected work/Projects(default) → Writing(sub
 - Typography plugin for prose styling (`@tailwindcss/typography`)
 - Theme switching lives entirely in `Header.astro` (dropdown, `Cmd/Ctrl + /` cycling, OS-preference sync) plus the inline anti-flash script in `Layout.astro`. `src/config/themes.ts` is the single source of theme ids (`LIGHT_THEME` / `DARK_THEME`); since `is:inline` scripts cannot import, `Layout.astro` passes them to the anti-flash script through `data-light` / `data-dark` attributes rather than hardcoding them
 - The scroll progress bar is pure CSS (`animation-timeline: scroll()` in `global.css`), decorative and `aria-hidden`. Browsers without scroll-driven animations simply do not show it
-- ESLint with TypeScript, Astro, and jsx-a11y plugins
+- ESLint with TypeScript and Astro plugins (`eslint.config.js`)
 - External links in markdown open in new tabs (`rehype-external-links` in `astro.config.js`)
 - Site constants in `src/consts.ts`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,7 +3,7 @@ version: alpha
 name: kalinichenko.dev
 description: >-
   Content-first editorial personal site. Warm "Terracotta + Slate" palette,
-  Gambetta display serif, one accent, two themes (light/dark). Tokens below are
+  DM Sans throughout, one accent, two themes (light/dark). Tokens below are
   the LIGHT theme (default); dark-theme values live in the "Themes" section of
   the body. Authoritative source of truth is src/styles/global.css CSS custom
   properties — this file mirrors them for humans and agents.
@@ -23,24 +23,24 @@ colors:
   accent-subtle: '#f7ebe4'
 typography:
   h1:
-    fontFamily: Gambetta
+    fontFamily: DM Sans
     fontSize: clamp(2rem, 4vw, 2.75rem)
     fontWeight: 600
     lineHeight: 1.2
     letterSpacing: -0.02em
   h2:
-    fontFamily: Gambetta
+    fontFamily: DM Sans
     fontSize: clamp(1.5rem, 3vw, 1.875rem)
     fontWeight: 600
     lineHeight: 1.2
     letterSpacing: -0.02em
   h3:
-    fontFamily: Gambetta
+    fontFamily: DM Sans
     fontSize: clamp(1.125rem, 2vw, 1.375rem)
     fontWeight: 600
     lineHeight: 1.2
   hero-name:
-    fontFamily: Gambetta
+    fontFamily: DM Sans
     fontSize: clamp(2.5rem, 5.5vw, 3.6rem)
     fontWeight: 600
   body:
@@ -117,12 +117,13 @@ and _how to apply_ it. The runtime source of truth is
 ## Overview
 
 **Direction: characterful, content-first, editorial.** Warmth and personality
-come from a warm palette, an expressive serif display face, and one restrained
+come from a warm palette, a confident heading scale, and one restrained
 interaction — not from gadgetry. Writing is the primary content; the design
 gets out of its way without going invisible.
 
-- **Fonts:** Gambetta (display/headings, Fontshare), DM Sans (body, Google),
-  JetBrains Mono (code + small mono labels, Google).
+- **Fonts:** DM Sans (headings and body, Google), JetBrains Mono (code + small
+  mono labels, Google). Two families only — headings and body share DM Sans and
+  separate by size, weight and tracking rather than by a second face.
 - **Two themes:** light (`data-theme="cloud"`) and dark
   (`data-theme="cloud-dark"`), plus `auto` (follows system). **Do not rename
   these ids** — the Giscus comment theme map and stored `localStorage`
@@ -171,8 +172,9 @@ for AA; light primary buttons use white on `--color-accent-text`.
 
 ## Typography
 
-- **Headings → Gambetta**, weight 600, tight tracking. Sizes scale with
-  `clamp()` (see tokens). The homepage hero name is the largest step.
+- **Headings → DM Sans**, weight 600, tight tracking (`-0.02em`). Sizes scale
+  with `clamp()` (see tokens). The homepage hero name is the largest step.
+  Headings carry their weight through size and tracking, not a contrasting face.
 - **Body → DM Sans**, 1rem / 1.65 for UI and supporting copy.
 - **Blog post body → `prose` step: 19px / 1.75** on the reading column. This is
   the deliberate "writing is the largest, most comfortable text" rule — the post
@@ -233,7 +235,7 @@ new one-off styles.
 - `.divider` — ornamental section rule with a short terracotta mark.
 - `.link-underline` — text link with an accent underline that draws on hover.
 - `.nav-link` — header nav item with an animated underline indicator.
-- `.prose-custom` — blog article prose (Gambetta headings, 19px/1.75 body,
+- `.prose-custom` — blog article prose (DM Sans headings, 19px/1.75 body,
   accent-text links, tinted code blocks).
 
 ## Interaction
@@ -310,7 +312,7 @@ scripts — no React/Motion in this project.
 
 1. Wrap it in `<section class="py-14 md:py-20">`; text goes in
    `.container-prose`, wide grids in `.container`.
-2. Lead with a Gambetta heading (default `h2`). No eyebrow.
+2. Lead with a `font-display` heading (default `h2`). No eyebrow.
 3. Build from the existing components (`.card`, `.btn-primary`, `.tag`,
    `.topic`, `.divider`, `.link-underline`).
 4. Accent usage: fills → `var(--color-accent)`; small text/links →

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Live at **[kalinichenko.dev](https://kalinichenko.dev)**
 - **Styling** — Tailwind CSS 4 via Vite plugin + Typography plugin
 - **Themes** — Light, Dark (+ Auto based on system preference)
 - **Content** — Astro Content Collections (Markdown blog posts, YAML projects)
-- **GitHub Repos** — Fetched at build time via Octokit custom content loader
+- **Projects** — Hand-maintained YAML content collection (no build-time API calls)
 - **Comments** — Giscus (GitHub Discussions)
-- **Fonts** — Gambetta, DM Sans, JetBrains Mono (via Astro's built-in font optimization)
+- **Fonts** — DM Sans, JetBrains Mono (via Astro's built-in font optimization)
 - **Linting** — ESLint + Prettier with Husky pre-commit hooks
 
 ## Getting Started


### PR DESCRIPTION
## Summary

Follow-up to #37. Three past code changes landed without updating the docs that describe them, so `README.md`, `CLAUDE.md` and `DESIGN.md` each described a stack that no longer exists.

## What was stale

| Doc claim                                  | Reality                                                                                   | Landed in |
| ------------------------------------------ | ----------------------------------------------------------------------------------------- | --------- |
| Gambetta display serif for headings        | Headings use DM Sans; Gambetta was removed from the font config and preload list          | d70deed   |
| ESLint runs a jsx-a11y plugin              | `eslint.config.js` loads only `@eslint/js`, `typescript-eslint` and `eslint-plugin-astro` | a82b5c7   |
| Projects fetched at build time via Octokit | Hand-maintained YAML collection, no API call at build time                                | d83603c   |

`DESIGN.md` mattered most here: `CLAUDE.md` points to it as the authoritative design system, and it still carried four `fontFamily: Gambetta` tokens in its front matter plus an "expressive serif display face" framing in the Overview. An agent reading it would have designed against a font the site does not load.

## Notes

- Headings and body both resolve to `--font-dm-sans`. Where the docs previously leaned on a serif/sans contrast, they now say headings separate by size, weight and tracking instead. The `--font-display` token is kept, so the "How to add a new page" step points at `font-display` rather than naming a family.
- The Octokit fix was not in the original list I flagged; I found it while confirming the other two. `CLAUDE.md` already documented the YAML approach correctly, so only `README.md` disagreed.
- The one surviving `octokit` mention is in `content/posts/best-pull-request-deletes-more-than-it-adds.md`, which is a post _about_ removing it. Left intact deliberately.

## Test plan

- [x] `grep -rni gambetta` over the repo returns nothing
- [x] `grep -rni jsx-a11y` returns only an uninstalled optional peer entry in `package-lock.json`
- [x] `grep -rni octokit` returns only the blog post narrating its removal
- [x] `npm run format:check` clean (DESIGN.md front matter still parses)

Docs only, no behavior change.
