### PR TITLE
Drop the divider between the hero and the projects section

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -224,7 +224,8 @@ Sections use vertical rhythm `py-14 md:py-20`. Separate two adjacent
 default-background sections with `<hr class="divider" />` (an ornamental
 hairline with a short terracotta mark) inside a `.container`, or give one of the
 two a `bg-background-subtle`. The homepage keeps a single subtle-background
-section (Writing); the rest are default with a divider where they touch.
+section (Writing) and no dividers: the sections carry enough vertical rhythm to
+separate themselves, so `.divider` is available but currently unused.
 
 ## Shapes & Elevation
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,6 @@ const projects = (await getCollection('projects'))
 <Layout>
   <script type="application/ld+json" is:inline set:html={JSON.stringify(personSchema)} />
   <HeroSection />
-  <div class="container"><hr class="divider" data-reveal="content" /></div>
   <ProjectsSection projects={projects} githubProfileLink={GITHUB_PROFILE_LINK} />
   {allPosts.length > 0 && <BlogSection latestPosts={latestPosts} />}
   <ContactSection mailProfileLink={MAIL_PROFILE_LINK} linkedinProfileLink={LINKEDIN_PROFILE_LINK} />


### PR DESCRIPTION
## Summary
- Removes the `<hr class="divider">` that sat between the hero and the Selected work section on the homepage.
- Updates `DESIGN.md` so the homepage description matches: one subtle-background section (Writing), no dividers.

## Notes
- `.divider` itself is untouched in `global.css` and still documented as an available component, it just has no callers right now.

## Test plan
- Visual check of `/` — sections now flow straight from hero into projects.